### PR TITLE
update eval.py for easier use

### DIFF
--- a/examples/add_new_data_opencanopy.ipynb
+++ b/examples/add_new_data_opencanopy.ipynb
@@ -141,10 +141,16 @@
     "```bash\n",
     "python src/train.py model=my_custom_model\n",
     "```\n",
+    "\n",
     "For evaluation only:\n",
     "```bash\n",
-    "python src/eval.py\n",
-    "```\n"
+    "python src/eval.py <checkpoint_path> <train_config_path> task_name=test [extra_hydra_arg]\n",
+    "```\n",
+    "\n",
+    "For prediction:\n",
+    "```bash\n",
+    "python src/eval.py <checkpoint_path> <train_config_path> task_name=predict [extra_hydra_arg]\n",
+    "```"
    ]
   },
   {


### PR DESCRIPTION
This pull request updates the evaluation workflow to require explicit paths for both the checkpoint and config files, and updates documentation to reflect these changes. The main improvements are to make evaluation and prediction more flexible and explicit, and to clarify usage for users.

**Evaluation and prediction workflow improvements:**

* The `src/eval.py` script now requires users to provide both the checkpoint path and the config file path as command-line arguments, instead of inferring them from a training directory. This makes the script more flexible and less dependent on directory structure.
* Added explicit checks for the existence and correct file extensions of the provided checkpoint (`.ckpt`) and config (`.yaml`) files, improving error handling and user feedback.

**Documentation updates:**

* Updated `examples/add_new_data_opencanopy.ipynb` to show the new usage pattern for evaluation and prediction, including the required arguments and example commands. Also added a new section for prediction usage.
